### PR TITLE
Fix: Handle Japanese tags correctly on GitHub Pages

### DIFF
--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -38,13 +38,13 @@ export async function generateStaticParams() {
   });
 
   return Array.from(tagSet).map(tag => ({
-    tag: encodeURIComponent(tag),
+    tag: tag,
   }));
 }
 
 export default async function TagPage({ params }: PageProps) {
   const resolvedParams = await params;
-  const decodedTag = decodeURIComponent(resolvedParams.tag);
+  const decodedTag = resolvedParams.tag;
   const notesDir = path.join(process.cwd(), 'notes');
   const files = fs.readdirSync(notesDir, { recursive: true })
     .filter((file): file is string => typeof file === 'string' && file.endsWith('.md'));


### PR DESCRIPTION
Previously, pages for tags containing Japanese characters resulted in a 404 error when deployed to GitHub Pages. This was likely due to how GitHub Pages handles percent-encoded filenames versus percent-encoded URL paths.

This commit addresses the issue by:
1. Modifying `generateStaticParams` in `src/app/tags/[tag]/page.tsx` to generate static paths using raw (decoded) tag names (e.g., '日本語') instead of percent-encoded names. This results in file paths like `out/tags/日本語/index.html`.
2. Updating the `TagPage` component in `src/app/tags/[tag]/page.tsx` to use the `params.tag` directly, as Next.js routing provides the decoded value when mapping from a percent-encoded URL to a filesystem path with non-encoded UTF-8 characters.
3. Verified that links to tag pages in `src/app/tags/page.tsx` continue to correctly use `encodeURIComponent` in the `href` attribute, ensuring valid URL formation.