### PR TITLE
Fix: Attempt to resolve 404s for Japanese tags on GitHub Pages

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
-  trailingSlash: true,
+  trailingSlash: false, // <-- Changed line
 };
 
 export default nextConfig;

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -38,13 +38,13 @@ export async function generateStaticParams() {
   });
 
   return Array.from(tagSet).map(tag => ({
-    tag: tag,
+    tag: encodeURIComponent(tag),
   }));
 }
 
 export default async function TagPage({ params }: PageProps) {
   const resolvedParams = await params;
-  const decodedTag = resolvedParams.tag;
+  const decodedTag = decodeURIComponent(resolvedParams.tag); // <-- Changed back to this
   const notesDir = path.join(process.cwd(), 'notes');
   const files = fs.readdirSync(notesDir, { recursive: true })
     .filter((file): file is string => typeof file === 'string' && file.endsWith('.md'));
@@ -58,7 +58,7 @@ export default async function TagPage({ params }: PageProps) {
       return {
         slug: file.replace(/\.md$/, '').split(path.sep),
         title: data.title || file.replace(/\.md$/, ''),
-        tags: (data.tags || []).map((t: string) => decodeURIComponent(t)),
+        tags: data.tags || [], // <-- Changed line
         date: stats.birthtime.toISOString()
       };
     })


### PR DESCRIPTION
This commit tries a new approach to fix 404 errors for tags with Japanese characters on GitHub Pages, based on your feedback that the previous fix was not effective.

Changes include:
1. Set `trailingSlash: false` in `next.config.ts`. This changes URL and file generation to not use trailing slashes (e.g., `/tags/tagname.html` instead of `/tags/tagname/index.html`).
2. Reverted `generateStaticParams` in `src/app/tags/[tag]/page.tsx` to output percent-encoded tag names. Combined with `trailingSlash: false`, this will lead to filenames like `out/tags/%E6%9C%AAAC.html`.
3. Reverted the main `TagPage` component in `src/app/tags/[tag]/page.tsx` to expect percent-encoded params and decode them, consistent with the change to `generateStaticParams`.
4. Verified that article links generated via `NoteLink` do not include trailing slashes, aligning with the `trailingSlash: false` setting.
5. Corrected the handling of tags from frontmatter in `src/app/tags/[tag]/page.tsx` by removing an unnecessary `decodeURIComponent` call, as these tags are already in their raw form.