### PR TITLE
Fix: Use raw tags for paths and links for GitHub Pages

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,7 @@ const nextConfig: NextConfig = {
   images: {
     unoptimized: true,
   },
-  trailingSlash: false, // <-- Changed line
+  trailingSlash: true, // <-- Changed line
 };
 
 export default nextConfig;

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -38,13 +38,13 @@ export async function generateStaticParams() {
   });
 
   return Array.from(tagSet).map(tag => ({
-    tag: encodeURIComponent(tag),
+    tag: tag, // <-- Changed line
   }));
 }
 
 export default async function TagPage({ params }: PageProps) {
   const resolvedParams = await params;
-  const decodedTag = decodeURIComponent(resolvedParams.tag); // <-- Changed back to this
+  const decodedTag = resolvedParams.tag; // <-- Changed line
   const notesDir = path.join(process.cwd(), 'notes');
   const files = fs.readdirSync(notesDir, { recursive: true })
     .filter((file): file is string => typeof file === 'string' && file.endsWith('.md'));

--- a/src/app/tags/page.tsx
+++ b/src/app/tags/page.tsx
@@ -40,7 +40,7 @@ export default function TagsPage() {
         {tags.map(({ tag, count }) => (
           <Link
             key={tag}
-            href={`/tags/${encodeURIComponent(tag)}`}
+            href={`/tags/${tag}`} // <-- Changed line
             className="p-4 border rounded-lg hover:bg-gray-50 transition-colors"
           >
             <div className="flex justify-between items-center">


### PR DESCRIPTION
This is my third attempt to resolve 404 errors for tags with Japanese characters on GitHub Pages. I'm basing this on your feedback indicating that URLs are being resolved to a raw (decoded) form with a trailing slash (e.g., /tags/未AC/).

This commit implements the following strategy:
1. Ensures `trailingSlash: true` in `next.config.ts` to support `directory/index.html` structures.
2. Configures `generateStaticParams` in `src/app/tags/[tag]/page.tsx` to use raw (decoded) tag names for path generation. This should result in Next.js creating directories with names like `out/tags/未AC/index.html`.
3. Updates the `TagPage` component in `src/app/tags/[tag]/page.tsx` to expect these raw tag names as parameters.
4. Modifies the link generation in `src/app/tags/page.tsx` to use raw (decoded) tag names in the `href` attributes of `Link` components. This ensures that generated links match the directory structure (e.g., `/tags/未AC`).